### PR TITLE
remove relative paths in npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "scripts": {
     "test": "make",
     "start": "npm run serve && npm run dev",
-    "serve": "./node_modules/.bin/http-server",
-    "css": "./node_modules/.bin/webpack --colors --progress --config stylus.config.js",
-    "lib": "./node_modules/.bin/gulp && npm run css",
-    "dist": "./node_modules/.bin/webpack --progress --colors --config dist.config.js",
-    "dist.min": "./node_modules/.bin/webpack --progress --colors --optimize-minimize --optimize-occurence-order --optimize-dedupe --config dist.min.config.js",
+    "serve": "http-server",
+    "css": "webpack --colors --progress --config stylus.config.js",
+    "lib": "gulp && npm run css",
+    "dist": "webpack --progress --colors --config dist.config.js",
+    "dist.min": "webpack --progress --colors --optimize-minimize --optimize-occurence-order --optimize-dedupe --config dist.min.config.js",
     "build": "npm run dist && npm run dist.min && npm run lib",
-    "dev": "./node_modules/.bin/webpack-dev-server --progress --colors --port 8090"
+    "dev": "webpack-dev-server --progress --colors --port 8090"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
I've been trying to debug this on React 0.13 and I happened to notice that you're using relative paths in your scripts -- this isn't necessary, since npm adds executables of all installed dependencies to the $PATH for (see http://blog.ibangspacebar.com/npm-scripts for more info)